### PR TITLE
fix: avoid calling the observer in an endless loop

### DIFF
--- a/ios/Emm.swift
+++ b/ios/Emm.swift
@@ -187,11 +187,8 @@ class ReactNativeEmm: RCTEventEmitter {
             return
         }
         
-        var initial = self.sharedUserDefaults?.dictionary(forKey: self.configurationKey)
-        if (initial == nil) {
-            initial = Dictionary<String, Any>()
-        }
-        let equal = NSDictionary(dictionary: initial!).isEqual(to: config!)
+        let initial = self.sharedUserDefaults?.dictionary(forKey: self.configurationKey) ?? Dictionary<String, Any>()
+        let equal = NSDictionary(dictionary: initial).isEqual(to: config!)
         
 
         if (self.appGroupId != nil && !equal) {

--- a/ios/Emm.swift
+++ b/ios/Emm.swift
@@ -180,18 +180,26 @@ class ReactNativeEmm: RCTEventEmitter {
 
     @objc func managedConfigChaged(notification: Notification) -> Void {
         let config = managedConfig()
-        var result = Dictionary<String, Any>()
-        
-        if (config != nil) {
-            result = config!
+        if (config == nil) {
+            if (self.sharedUserDefaults?.dictionary(forKey: self.configurationKey) != nil) {
+                self.sharedUserDefaults?.removeObject(forKey: self.configurationKey)
+            }
+            return
         }
+        
+        var initial = self.sharedUserDefaults?.dictionary(forKey: self.configurationKey)
+        if (initial == nil) {
+            initial = Dictionary<String, Any>()
+        }
+        let equal = NSDictionary(dictionary: initial!).isEqual(to: config!)
+        
 
-        if (self.appGroupId != nil) {
-            self.sharedUserDefaults?.set(result, forKey: self.configurationKey)
+        if (self.appGroupId != nil && !equal) {
+            self.sharedUserDefaults?.set(config, forKey: self.configurationKey)
         }
         
         if (hasListeners) {
-            sendEvent(withName: "managedConfigChanged", body: result)
+            sendEvent(withName: "managedConfigChanged", body: config)
         }
     }
 


### PR DESCRIPTION
This PR avoid the iOS observer from firing on an endless loop by not setting the UserDefaults if previous and new matches its values.