### PR TITLE
Move ManagedConfigCallback type and update README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,9 +170,9 @@ import Emm from '@mattermost/react-native-emm';
 * [setAppGroupId](#setappgroupid)
 
 ### Types
-* [AuthenticateConfig](/types/authenticate.d.ts)
-* [AuthenticationMethods](/types/authenticate.d.ts)
-* [ManagedConfigCallBack](/types/events.d.ts)
+* [AuthenticateConfig](/src/types/authenticate.ts)
+* [AuthenticationMethods](/src/types/authenticate.ts)
+* [ManagedConfigCallBack](/src/types/events.ts)
 
 #### addListener
 `addListener(callback: ManagedConfigCallBack): EmitterSubscription;`

--- a/src/emm.ts
+++ b/src/emm.ts
@@ -9,19 +9,18 @@ import type {
   AuthenticateConfig,
   AuthenticationMethods,
 } from './types/authenticate';
-import type { EnterpriseMobilityManager } from './types/managed';
-import type { ManagedConfigCallBack } from './types/events';
+import type { EnterpriseMobilityManager, ManagedConfig, ManagedConfigCallBack } from './types/managed';
 
 const { Emm } = NativeModules;
 
 const emitter =
   Platform.OS === 'ios' ? new NativeEventEmitter(Emm) : DeviceEventEmitter;
-let cachedConfig: Record<string, any> = {};
+let cachedConfig: ManagedConfig = {};
 
 const EMM: EnterpriseMobilityManager = {
   ...Emm,
   addListener: (callback: ManagedConfigCallBack) => {
-    return emitter.addListener('managedConfigChanged', (config: any) => {
+    return emitter.addListener('managedConfigChanged', (config: ManagedConfig) => {
       cachedConfig = config;
 
       if (callback && typeof callback === 'function') {
@@ -50,9 +49,9 @@ const EMM: EnterpriseMobilityManager = {
       return cachedConfig;
     }
 
-    const managed = await Emm.getManagedConfig();
-    if (managed) {
-      cachedConfig = managed;
+    const config = await Emm.getManagedConfig();
+    if (config) {
+      cachedConfig = config;
     }
 
     return cachedConfig;

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -1,3 +1,0 @@
-export type ManagedConfigCallBack = {
-  (config: any): void;
-};

--- a/src/types/managed.ts
+++ b/src/types/managed.ts
@@ -1,6 +1,13 @@
 import type { EmitterSubscription } from 'react-native';
 import type { AuthenticateConfig, AuthenticationMethods } from './authenticate';
-import type { ManagedConfigCallBack } from './events';
+
+export interface ManagedConfig {
+  [key: string]: any;
+}
+
+export type ManagedConfigCallBack = {
+  (config: ManagedConfig): void;
+};
 
 export interface EnterpriseMobilityManager {
   addListener(callback: ManagedConfigCallBack): EmitterSubscription;
@@ -20,8 +27,4 @@ export interface EnterpriseMobilityManager {
   openSecuritySettings(): void;
 
   setAppGroupId(identifier: string): void;
-}
-
-export interface ManagedConfig {
-  [key: string]: any;
 }


### PR DESCRIPTION
#### Summary
It wasn't clear to me that the `ManagedConfigCallback` was passed a `ManagedConfig` when looking at how we use this library in the `mattermost-mobile`'s `EmmProvider` class. Updated the types here to make it explicit.

