### PR TITLE
Fix ios navigation

### DIFF
--- a/ios/ScreenCaptureManager.swift
+++ b/ios/ScreenCaptureManager.swift
@@ -110,7 +110,7 @@
     }
     
     private func applyScreenCapturePolicy() {
-        DispatchQueue.main.sync {
+        DispatchQueue.main.async {
             for rootVC in self.getAllRootViewControllers() {
                 let c = NSStringFromClass(type(of: rootVC))
                 if c.contains("RNNStackController"), let r = rootVC as? UINavigationController {


### PR DESCRIPTION
#### Summary
Two fixes added
1. we are now applying the screen capture policy with async to not block the UI thread
2. we are now ensuring the observeLifecycle happens only once per viewController

#### Redundant Calls to observeLifecycle(of:)
What Went Wrong?
* Every time a view controller was pushed, we called observeLifecycle(of:) again, even if the view controller had already been observed.
* This meant that for each navigation event, we were re-adding the same observer to the same view controller.

#### Navigation Stack Processing Calls observeLifecycle on All View Controllers
What Went Wrong?
* Every time the navigation stack changed (via setViewControllers), we re-iterated over every ViewController and attached a new observer.
* If a view controller remained in the stack but was already observed, it still got reprocessed.

### Key Fix: Only Attach the Observer Once
```swift
if objc_getAssociatedObject(viewController, &AssociatedKeys.didObserveLifecycle) == nil {
    observeLifecycle(of: viewController)
    objc_setAssociatedObject(viewController, &AssociatedKeys.didObserveLifecycle, true, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
}
```

How This Works
1. Before attaching the observer, we check if didObserveLifecycle has already been set.
2. If it has not been set, we:
    * Call observeLifecycle(of:) to attach the observer.
    * Mark the view controller as "observed" by setting didObserveLifecycle = true using objc_setAssociatedObject.
3. If didObserveLifecycle is already set, we skip the observer attachment.

Now, observeLifecycle(of:) Runs Only Once Per ViewController
* The first time a view controller appears in the navigation stack, it gets an observer.
* The next time it's processed (e.g., on pushViewController or setViewControllers), it is skipped because it was already observed.
* No duplicate event listeners are created.