### PR TITLE
New arch compilation issue fix on applyBlurEffect

### DIFF
--- a/android/src/newarch/java/com/EmmModule.kt
+++ b/android/src/newarch/java/com/EmmModule.kt
@@ -101,8 +101,8 @@ class EmmModule(reactContext: ReactApplicationContext) : NativeEmmSpec(reactCont
     // Keep: Required for RN built in Event Emitter Calls
   }
 
-  override fun applyBlurEffect(radius: Float = 10f) {
-    implementation.applyBlurEffect(radius)
+  override fun applyBlurEffect(radius: Double) {
+    implementation.applyBlurEffect(radius.toFloat())
   }
 
   override fun removeBlurEffect() {

--- a/src/NativeEmm.ts
+++ b/src/NativeEmm.ts
@@ -1,5 +1,5 @@
 import {type TurboModule, TurboModuleRegistry} from 'react-native';
-import type { Float, UnsafeObject } from 'react-native/Libraries/Types/CodegenTypes';
+import type { UnsafeObject } from 'react-native/Libraries/Types/CodegenTypes';
 
 type AuthenticateConfig = {
   reason?: string;
@@ -28,7 +28,7 @@ export interface Spec extends TurboModule {
     openSecuritySettings: () => void;
     setAppGroupId: (identifier: string) => void;
     setBlurScreen: (enabled: boolean) => void;
-    applyBlurEffect: (radius: Float) => void;
+    applyBlurEffect: (radius: number) => void;
     removeBlurEffect: () => void;
 };
 


### PR DESCRIPTION
this MR fix the issue described on https://github.com/mattermost/react-native-emm/issues/20

making this change fix the issue for me on Expo 52.


