### PR TITLE
iOS modal full screen modal

### DIFF
--- a/android/src/main/java/com/mattermost/emm/EmmModuleImpl.kt
+++ b/android/src/main/java/com/mattermost/emm/EmmModuleImpl.kt
@@ -123,7 +123,7 @@ class EmmModuleImpl(reactApplicationContext: ReactApplicationContext) {
             val executor: Executor = ContextCompat.getMainExecutor(activity.applicationContext)
 
             if (blurOnAuthenticate) {
-                applyBlurEffect(8f)
+                applyBlurEffect(8.0)
             }
             val biometricPrompt = BiometricPrompt(activity, executor, object : BiometricPrompt.AuthenticationCallback() {
                 override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {

--- a/android/src/main/java/com/mattermost/emm/EmmModuleImpl.kt
+++ b/android/src/main/java/com/mattermost/emm/EmmModuleImpl.kt
@@ -273,7 +273,7 @@ class EmmModuleImpl(reactApplicationContext: ReactApplicationContext) {
         return true
     }
 
-    fun applyBlurEffect(radius: Float) {
+    fun applyBlurEffect(radius: Double) {
         val activity: Activity? = context.currentActivity
         activity?.runOnUiThread {
             val decorView = activity.window.decorView as ViewGroup
@@ -293,7 +293,7 @@ class EmmModuleImpl(reactApplicationContext: ReactApplicationContext) {
 
                     setupWith(rootView, blurAlgorithm)
                         .setFrameClearDrawable(decorView.background)
-                        .setBlurRadius(radius)
+                        .setBlurRadius(radius.toFloat())
                         .setBlurAutoUpdate(true)
                 }
 

--- a/android/src/newarch/java/com/EmmModule.kt
+++ b/android/src/newarch/java/com/EmmModule.kt
@@ -101,7 +101,7 @@ class EmmModule(reactContext: ReactApplicationContext) : NativeEmmSpec(reactCont
     // Keep: Required for RN built in Event Emitter Calls
   }
 
-  override fun applyBlurEffect(radius: Float = 10f) {
+  override fun applyBlurEffect(radius: Double = 10.0) {
     implementation.applyBlurEffect(radius)
   }
 

--- a/android/src/newarch/java/com/EmmModule.kt
+++ b/android/src/newarch/java/com/EmmModule.kt
@@ -101,7 +101,7 @@ class EmmModule(reactContext: ReactApplicationContext) : NativeEmmSpec(reactCont
     // Keep: Required for RN built in Event Emitter Calls
   }
 
-  override fun applyBlurEffect(radius: Double = 10.0) {
+  override fun applyBlurEffect(radius: Double) {
     implementation.applyBlurEffect(radius)
   }
 

--- a/android/src/oldarch/java/com/EmmModule.kt
+++ b/android/src/oldarch/java/com/EmmModule.kt
@@ -108,7 +108,7 @@ class EmmModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
   }
 
     @ReactMethod
-    fun applyBlurEffect(radius: Double = 10.0) {
+    fun applyBlurEffect(radius: Double) {
         implementation.applyBlurEffect(radius)
     }
 

--- a/android/src/oldarch/java/com/EmmModule.kt
+++ b/android/src/oldarch/java/com/EmmModule.kt
@@ -108,7 +108,7 @@ class EmmModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
   }
 
     @ReactMethod
-    fun applyBlurEffect(radius: Float = 10f) {
+    fun applyBlurEffect(radius: Double = 10.0) {
         implementation.applyBlurEffect(radius)
     }
 

--- a/ios/Emm.mm
+++ b/ios/Emm.mm
@@ -69,7 +69,7 @@ RCT_REMAP_METHOD(setBlurScreen, enabled:(BOOL)enabled) {
     [self setBlurScreen:enabled];
 }
 
-RCT_REMAP_METHOD(applyBlurEffect, radius:(CGFloat)radius) {
+RCT_REMAP_METHOD(applyBlurEffect, radius:(double)radius) {
     [self applyBlurEffect:radius];
 }
 
@@ -158,7 +158,7 @@ RCT_REMAP_METHOD(removeBlurEffect, removeBlur) {
     [wrapper setBlurScreenWithEnabled:enabled];
 }
 
--(void)applyBlurEffect:(CGFloat)radius {
+-(void)applyBlurEffect:(double)radius {
     [[ScreenCaptureManager shared] applyBlurEffectWithRadius:radius];
 }
 

--- a/ios/Emm.swift
+++ b/ios/Emm.swift
@@ -14,7 +14,7 @@ import React
     
     @objc public func captureEvents() {
         NotificationCenter.default.addObserver(self, selector: #selector(managedConfigChaged(notification:)), name: UserDefaults.didChangeNotification, object: nil)
-        NotificationCenter.default.addObserver(ScreenCaptureManager.shared, selector: #selector(ScreenCaptureManager.applyBlurEffect(radius:)), name: UIApplication.willResignActiveNotification, object: nil)
+        NotificationCenter.default.addObserver(ScreenCaptureManager.shared, selector: #selector(ScreenCaptureManager.applyBlurEffect(notification:)), name: UIApplication.willResignActiveNotification, object: nil)
         NotificationCenter.default.addObserver(ScreenCaptureManager.shared, selector: #selector(ScreenCaptureManager.removeBlurEffect), name: UIApplication.didBecomeActiveNotification, object: nil)
     }
     

--- a/ios/Extensions/UIViewController+Shield.swift
+++ b/ios/Extensions/UIViewController+Shield.swift
@@ -88,11 +88,17 @@ extension UIViewController {
         }
         
         print("✅ Applying screen capture protection to: \(targetView.nativeID ?? "Unknown View")")
+        var isModalFullScreen = false
+        if let parentVC = self.parent,
+           parentVC.modalPresentationStyle == .overFullScreen || parentVC.modalPresentationStyle == .fullScreen
+            || parentVC.modalPresentationStyle == .overCurrentContext || parentVC.modalPresentationStyle == .currentContext {
+            isModalFullScreen = true
+        }
         var isModal = self.isModalInPresentation
         if let navigationController = self.navigationController,
            let rootViewController = navigationController.viewControllers.first,
            rootViewController.presentingViewController != nil {
-            isModal = true
+            isModal = !isModalFullScreen
         }
         
         targetView.setScreenCaptureProtection(isModal)

--- a/ios/Extensions/UIViewController+Shield.swift
+++ b/ios/Extensions/UIViewController+Shield.swift
@@ -92,6 +92,8 @@ extension UIViewController {
         if let parentVC = self.parent,
            parentVC.modalPresentationStyle == .overFullScreen || parentVC.modalPresentationStyle == .fullScreen
             || parentVC.modalPresentationStyle == .overCurrentContext || parentVC.modalPresentationStyle == .currentContext {
+            // Full-screen modals (e.g., .overFullScreen, .fullScreen) should not be treated as modals
+            // for screen capture protection but rather as regular screens.
             isModalFullScreen = true
         }
         var isModal = self.isModalInPresentation

--- a/ios/ScreenCaptureManager.swift
+++ b/ios/ScreenCaptureManager.swift
@@ -134,7 +134,7 @@
     }
     
     // MARK: Blur effect functions
-    func createBlurEffect(window: UIWindow, toImage image: inout UIImage, radius: CGFloat) {
+    func createBlurEffect(window: UIWindow, toImage image: inout UIImage, radius: Double) {
         let ciImage = CIImage(image: image)
         let filter = CIFilter(name: "CIGaussianBlur")
         filter?.setValue(ciImage, forKey: "inputImage")
@@ -162,7 +162,7 @@
         return screenshot ?? UIImage()
     }
     
-    @objc public func applyBlurEffect(radius: CGFloat = 8) {
+    @objc public func applyBlurEffect(radius: Double = 8.0) {
         if self.blurView == nil && (
                 (self.preventScreenCapture && !self.isAuthenticating) ||
                 (self.isAuthenticating && self.blurOnAuthenticate)
@@ -178,7 +178,7 @@
                     blurView.contentMode = .scaleToFill
                     blurView.backgroundColor = UIColor.gray
                     window.addSubview(blurView)
-                    self.createBlurEffect(window: window, toImage: &cover, radius: 8)
+                    self.createBlurEffect(window: window, toImage: &cover, radius: radius)
                     blurView.image = cover
                 }
             }

--- a/ios/ScreenCaptureManager.swift
+++ b/ios/ScreenCaptureManager.swift
@@ -26,7 +26,7 @@
         if self.preventScreenCapture {
             NotificationCenter.default.addObserver(
                 self,
-                selector: #selector(applyBlurEffect),
+                selector: #selector(applyBlurEffect(notification:)),
                 name: UIScreen.capturedDidChangeNotification,
                 object: nil
             )
@@ -162,7 +162,12 @@
         return screenshot ?? UIImage()
     }
     
-    @objc public func applyBlurEffect(radius: Double = 8.0) {
+    @objc func applyBlurEffect(notification: Notification) {
+        self.applyBlurEffect(radius: 10.0)
+    }
+
+    
+    @objc public func applyBlurEffect(radius: Double = 10.0) {
         if self.blurView == nil && (
                 (self.preventScreenCapture && !self.isAuthenticating) ||
                 (self.isAuthenticating && self.blurOnAuthenticate)

--- a/src/NativeEmm.ts
+++ b/src/NativeEmm.ts
@@ -1,5 +1,5 @@
 import {type TurboModule, TurboModuleRegistry} from 'react-native';
-import type { Float, UnsafeObject } from 'react-native/Libraries/Types/CodegenTypes';
+import type { Double, UnsafeObject } from 'react-native/Libraries/Types/CodegenTypes';
 
 type AuthenticateConfig = {
   reason?: string;
@@ -28,7 +28,7 @@ export interface Spec extends TurboModule {
     openSecuritySettings: () => void;
     setAppGroupId: (identifier: string) => void;
     setBlurScreen: (enabled: boolean) => void;
-    applyBlurEffect: (radius: Float) => void;
+    applyBlurEffect: (radius: Double) => void;
     removeBlurEffect: () => void;
 };
 


### PR DESCRIPTION
#### Summary

When applying the screen capture protection, if the modal being opened was of type `fullScreen`, `overFullScreen`, `currentContext` or `overCurrentContext` which basically opens the modal taking the entire screen space, the elements behind the secure view were not responding to scrolling.

Fixes: #20 according to #22 

#### Ticket Link
TDB
