### PR TITLE
Update EmmModule.onActivityResult function signature to work with newer versions

### DIFF
--- a/android/src/newarch/java/com/EmmModule.kt
+++ b/android/src/newarch/java/com/EmmModule.kt
@@ -22,7 +22,7 @@ class EmmModule(reactContext: ReactApplicationContext) : NativeEmmSpec(reactCont
   }
 
   private val mActivityEventListener = object : BaseActivityEventListener() {
-    override fun onActivityResult(activity: Activity?, requestCode: Int, resultCode: Int, data: Intent?) {
+    override fun onActivityResult(activity: Activity, requestCode: Int, resultCode: Int, data: Intent?) {
       implementation.handleActivityResult(authPromise, activity, requestCode, resultCode, data)
       authPromise = null
     }


### PR DESCRIPTION
Hi, 

in continue to issue #24, here's a fix to the onActivityResult function signature.

I'm not 100% sure, but it seems like the react team converted LifecycleEventListener from Java to Kotlin which let the compiler "understand" that the signature isn't correct.

I've tested this change with expo 53 (0.79.5) and also expo 54 (react-native 0.81.4) and it seems to work fine.

I've also tried fixing other errors, but it the deprecations seems to be mainly related to the old arch support.
so maybe it will be a good idea to first remove old arch and then the issues.

